### PR TITLE
[WIP] Adds merge of formatted summaries to the TAP13Listener class

### DIFF
--- a/src/test-runner/tap13-listener.js
+++ b/src/test-runner/tap13-listener.js
@@ -127,6 +127,24 @@ class TAP13Listener {
     }
 
     /**
+     * @param {object} summaries .
+     * @return {object} .
+     */
+    static mergeFormattedSummaries (summaries) {
+        return summaries.reduce((mergedSummary, summary) => {
+            Object.keys(summary).forEach(key => {
+                if (mergedSummary[key]) {
+                    mergedSummary[key] += summary[key];
+                } else {
+                    mergedSummary[key] = summary[key];
+                }
+            });
+
+            return mergedSummary;
+        }, {});
+    }
+
+    /**
      * @param {TestResult[]} summary .
      * @return {object} .
      */

--- a/src/test-runner/test-runner.js
+++ b/src/test-runner/test-runner.js
@@ -71,7 +71,7 @@ class TestRunner extends EventEmitter {
         const result = new TestResult(test);
 
         const util = new WhiskerUtil(vm, project);
-        await util.prepare(props.frequency);
+        await util.prepare(props.accelerationFactor);
 
         const testDriver = util.getTestDriver(
             {

--- a/src/test/whisker-util.js
+++ b/src/test/whisker-util.js
@@ -20,8 +20,8 @@ class WhiskerUtil {
         this.project = project;
     }
 
-    async prepare (frequency) {
-        await this.vmWrapper.setup(this.project, frequency);
+    async prepare (accelerationFactor) {
+        await this.vmWrapper.setup(this.project, accelerationFactor);
     }
 
     /**

--- a/src/test/whisker-util.js
+++ b/src/test/whisker-util.js
@@ -20,7 +20,7 @@ class WhiskerUtil {
         this.project = project;
     }
 
-    async prepare (accelerationFactor) {
+    async prepare (accelerationFactor = 1) {
         await this.vmWrapper.setup(this.project, accelerationFactor);
     }
 

--- a/src/test/whisker-util.js
+++ b/src/test/whisker-util.js
@@ -20,7 +20,7 @@ class WhiskerUtil {
         this.project = project;
     }
 
-    async prepare (accelerationFactor = 1) {
+    async prepare (accelerationFactor) {
         await this.vmWrapper.setup(this.project, accelerationFactor);
     }
 

--- a/src/vm/vm-wrapper.js
+++ b/src/vm/vm-wrapper.js
@@ -241,20 +241,20 @@ class VMWrapper {
 
     /**
      * @param {string} project .
-     * @param {number} frequency .
+     * @param {number} accelerationFactor .
      *
      * @returns {Promise<void>} .
      */
-    async setup (project, frequency) {
-        const setStepTime = freq => {
+    async setup (project, accelerationFactor) {
+        const setStepTime = factor => {
             delete Runtime.THREAD_STEP_INTERVAL;
-            Runtime.THREAD_STEP_INTERVAL = 1000 / freq;
+            Runtime.THREAD_STEP_INTERVAL = 1000 / 30 / factor;
             this.vm.runtime.currentStepTime = Runtime.THREAD_STEP_INTERVAL;
             this.stepper.setStepTime(Runtime.THREAD_STEP_INTERVAL);
             clearInterval(this.vm.runtime._steppingInterval);
-            this.accelerationFactor = Runtime.THREAD_STEP_INTERVAL_COMPATIBILITY / Runtime.THREAD_STEP_INTERVAL;
+            this.accelerationFactor = accelerationFactor;
         };
-        setStepTime(frequency);
+        setStepTime(accelerationFactor);
 
         this.instrumentPrimitive('control_wait', 'DURATION');
         this.instrumentPrimitive('looks_sayforsecs', 'SECS');

--- a/src/vm/vm-wrapper.js
+++ b/src/vm/vm-wrapper.js
@@ -245,7 +245,7 @@ class VMWrapper {
      *
      * @returns {Promise<void>} .
      */
-    async setup (project, accelerationFactor) {
+    async setup (project, accelerationFactor = 1) {
         const setStepTime = factor => {
             delete Runtime.THREAD_STEP_INTERVAL;
             Runtime.THREAD_STEP_INTERVAL = 1000 / 30 / factor;


### PR DESCRIPTION
Adds the capability to the TAP13Listener class to merge multiple already formatted coverages. This is used by the servant in the whisker-web repository, to merge the summaries from multiple parallel test-runs.

Needs: https://github.com/se2p/whisker-web/pull/7